### PR TITLE
countries list sort

### DIFF
--- a/src/account-settings/AccountSettingsPage.jsx
+++ b/src/account-settings/AccountSettingsPage.jsx
@@ -49,7 +49,6 @@ import {
   getStatesList,
 } from './data/constants';
 import { fetchSiteLanguages } from './site-language';
-import DemographicsSection from './demographics/DemographicsSection';
 import { fetchCourseList } from '../notification-preferences/data/thunks';
 import { withLocation, withNavigate } from './hoc';
 
@@ -65,7 +64,6 @@ class AccountSettingsPage extends React.Component {
     this.navLinkRefs = {
       '#basic-information': React.createRef(),
       '#profile-information': React.createRef(),
-      '#demographics-information': React.createRef(),
       '#social-media': React.createRef(),
       '#site-preferences': React.createRef(),
       '#linked-accounts': React.createRef(),
@@ -122,7 +120,7 @@ class AccountSettingsPage extends React.Component {
     countryOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.country.options.empty']),
-    }].concat(getCountryList(locale).map(({ code, name }) => ({ value: code, label: name }))),
+    }].concat(getCountryList(locale).map(({ code, name }) => ({ value: code, label: name })).sort((a, b) => a.label.localeCompare(b.label))),
     stateOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.state.options.empty']),
@@ -130,7 +128,7 @@ class AccountSettingsPage extends React.Component {
     languageProficiencyOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.language_proficiencies.options.empty']),
-    }].concat(getLanguageList(locale).map(({ code, name }) => ({ value: code, label: name }))),
+    }].concat(getLanguageList(locale).map(({ code, name }) => ({ value: code, label: name })).sort((a, b) => a.label.localeCompare(b.label))),
     yearOfBirthOptions: [{
       value: '',
       label: this.props.intl.formatMessage(messages['account.settings.field.year_of_birth.options.empty']),
@@ -460,16 +458,6 @@ class AccountSettingsPage extends React.Component {
     );
   }
 
-  renderDemographicsSection() {
-    // check the result of an LMS API call to determine if we should render the DemographicsSection component
-    if (this.props.formValues.shouldDisplayDemographicsSection) {
-      return (
-        <DemographicsSection forwardRef={this.navLinkRefs['#demographics-information']} />
-      );
-    }
-    return null;
-  }
-
   renderContent() {
     const editableFieldProps = {
       onChange: this.handleEditableFieldChange,
@@ -718,7 +706,6 @@ class AccountSettingsPage extends React.Component {
             {...editableFieldProps}
           />
         </div>
-        {getConfig().ENABLE_DEMOGRAPHICS_COLLECTION && this.renderDemographicsSection()}
         <div className="account-section pt-3 mb-5" id="social-media">
           <h2 className="section-heading h4 mb-3">
             {this.props.intl.formatMessage(messages['account.settings.section.social.media'])}
@@ -844,9 +831,7 @@ class AccountSettingsPage extends React.Component {
         <div>
           <div className="row">
             <div className="col-md-2">
-              <JumpNav
-                displayDemographicsLink={this.props.formValues.shouldDisplayDemographicsSection}
-              />
+              <JumpNav />
             </div>
             <div className="col-md-10">
               {loading ? this.renderLoading() : null}
@@ -888,7 +873,6 @@ AccountSettingsPage.propTypes = {
     social_link_twitter: PropTypes.string,
     time_zone: PropTypes.string,
     state: PropTypes.string,
-    shouldDisplayDemographicsSection: PropTypes.bool,
     useVerifiedNameForCerts: PropTypes.bool.isRequired,
     verified_name: PropTypes.string,
   }).isRequired,


### PR DESCRIPTION
### Description

Include a description of your changes here, along with a link to any relevant Jira tickets and/or GitHub issues.
Jira ticket:
https://ibemag.atlassian.net/browse/CUD-1985

- Country List: The country options list in getLocalizedOptions is now sorted alphabetically using .sort((a, b) => a.label.localeCompare(b.label)) after mapping the country codes and names.
- 
- Language List: Similarly, the language proficiency options list is also sorted alphabetically after being mapped.

This ensures that both lists are displayed in alphabetical order for better user experience.
